### PR TITLE
Change '$one-half' to '$one-two'

### DIFF
--- a/helpers/mixins/_responsive-grid.scss
+++ b/helpers/mixins/_responsive-grid.scss
@@ -21,7 +21,7 @@
 //---------------------------------
 
 // Magic Gridlyness @ 2-col
-$one-half: 50%;
+$one-two: 50%;
 
 // Magic Gridlyness @ 3-col
 $one-three: 33.33334%;


### PR DESCRIPTION
For the sake of consistency, I feel the 50% variable should follow the convention of all the other ones ($numerator-denominator).